### PR TITLE
Make favourites reactive

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,9 @@
 <template>
   <div id="app">
     <md-tabs md-alignment="fixed">
-     <md-tab id="tab-home" md-icon="home" md-label="Pokemons"><PokeArc :settings="settings"/></md-tab>
-     <md-tab id="tab-search" md-icon="search" md-label="Find Pokemon"><FindPoke :settings="settings"/></md-tab>
-     <md-tab id="tab-fav" md-icon="favorite" md-label="Favorites"><Favorite :settings="settings"/></md-tab>
+     <md-tab id="tab-home" md-icon="home" md-label="Pokemons"><PokeArc :settings="settings" v-on:favourite="onFavourite" :favourites="favourites"/></md-tab>
+     <md-tab id="tab-search" md-icon="search" md-label="Find Pokemon"><FindPoke :settings="settings" v-on:favourite="onFavourite" :favourites="favourites"/></md-tab>
+     <md-tab id="tab-fav" md-icon="favorite" md-label="Favorites"><Favorite :settings="settings" v-on:favourite="onFavourite" :favourites="favourites"/></md-tab>
      <md-tab id="tab-about" md-icon="pages" md-label="About"><About :settings="settings"/></md-tab>
      <md-tab id="tab-settings" md-icon="settings" md-label="Settings"><Settings :settings="settings" v-on:updateSettings="onUpdateSettings"/></md-tab>
     </md-tabs>
@@ -31,7 +31,8 @@ export default {
       githubProfile: 'https://github.com/mohitkyadav',
       settings: {
         showShiny: false
-      }
+      },
+      favourites: []
     }
   },
   created () {
@@ -39,11 +40,25 @@ export default {
       let settings = JSON.parse(localStorage.getItem('settings'))
       this.settings = settings
     }
+    if (localStorage.getItem('favourites')) {
+      let favourites = JSON.parse(localStorage.getItem('favourites'))
+      this.favourites = favourites
+    }
   },
   methods: {
     onUpdateSettings: function (settings) {
       this.settings = Object.assign({}, settings)
       localStorage.setItem('settings', JSON.stringify(settings))
+    },
+    onFavourite: function (pokeid) {
+      console.log('favourite', pokeid)
+      let index = this.favourites.indexOf(pokeid)
+      if (index > -1) {
+        this.favourites.splice(index, 1)
+      } else {
+        this.favourites.push(pokeid)
+      }
+      localStorage.setItem('favourites', JSON.stringify(this.favourites))
     },
     openUrl: function (url) {
       var win = window.open(url, '_blank')

--- a/src/components/FindPoke.vue
+++ b/src/components/FindPoke.vue
@@ -10,10 +10,6 @@
         <md-button id="search-btn" class="md-icon-button md-fab md-primary" v-on:click="searchPokemon()"><md-icon>search</md-icon><md-tooltip md-direction="bottom">Search</md-tooltip></md-button>
       </div>
     </md-toolbar>
-    <md-dialog-alert
-      :md-active.sync="popup"
-      md-content="Done, refresh the page to find your favourites."
-      md-confirm-text="Cool!" />
     <md-content class="md-scrollbar">
       <div class="not-found" v-if="err">
         <md-empty-state>
@@ -38,9 +34,14 @@
         <md-card-expand>
           <md-card-actions md-alignment="space-between">
             <div>
-                <md-button v-on:click="addToFav(pokemon.id)" @click="popup = true" class="md-icon-button">
-                    <md-icon>favorite<md-tooltip md-direction="bottom">Add to favorite</md-tooltip></md-icon>
-                </md-button>
+              <md-button v-on:click="toggleFavourite(pokemon.id)" class="md-icon-button">
+                  <md-icon v-if="favourites.includes(pokemon.id)">
+                    favorite<md-tooltip md-direction="bottom">Remove from favourites</md-tooltip>
+                  </md-icon>
+                  <md-icon v-else>
+                    favorite_border<md-tooltip md-direction="bottom">Add to favorites</md-tooltip>
+                  </md-icon>
+              </md-button>
             </div>
 
             <md-card-expand-trigger>
@@ -103,13 +104,11 @@
 <script>
 export default {
   name: 'FindPoke',
-  props: ['settings'],
+  props: ['settings', 'favourites'],
   data () {
     return {
       pokemon: null,
       err: null,
-      favPokemon: [],
-      popup: false,
       query: ''
     }
   },
@@ -129,14 +128,8 @@ export default {
         this.err = error.status
       })
     },
-    addToFav: function (pokeid) {
-      if (this.favPokemon.indexOf(pokeid) < 0) {
-        this.favPokemon.push(pokeid)
-      } else {
-        this.favPokemon.pop(this.favPokemon.indexOf(pokeid))
-      }
-      localStorage.setItem('favPokemon', JSON.stringify(this.favPokemon))
-      this.favPokemon = JSON.parse(localStorage.getItem('favPokemon'))
+    toggleFavourite: function (pokeid) {
+      this.$emit('favourite', pokeid)
     },
     searchPokemon: function () {
       document.getElementById('search-btn').classList.add('md-dense')

--- a/src/components/PokeArc.vue
+++ b/src/components/PokeArc.vue
@@ -1,13 +1,9 @@
 <template>
   <div class="container">
     <md-progress-bar id="progress-bar" md-mode="indeterminate"></md-progress-bar>
-    <md-dialog-alert
-      :md-active.sync="popup"
-      md-content="Done, refresh the page to find your favourites."
-      md-confirm-text="Cool!" />
     <md-content class="md-scrollbar">
       <ul>
-        <li v-for="pokemon in pokemons">
+        <li v-for="pokemon in pokemons" :key="pokemon.id">
           <md-card md-with-hover class="md-elevation-20">
             <md-card-media>
               <img style="height:180px;width:180px;" v-bind:src="(settings.showShiny) ? pokemon.sprites.front_shiny : pokemon.sprites.front_default" alt="People">
@@ -21,9 +17,14 @@
             <md-card-expand>
               <md-card-actions md-alignment="space-between">
                 <div>
-                    <md-button v-on:click="addToFav(pokemon.id)" @click="popup = true" class="md-icon-button">
-                        <md-icon>favorite<md-tooltip md-direction="bottom">Add to favorite</md-tooltip></md-icon>
-                    </md-button>
+                  <md-button v-on:click="toggleFavourite(pokemon.id)" class="md-icon-button">
+                      <md-icon v-if="favourites && favourites.includes(pokemon.id)">
+                        favorite<md-tooltip md-direction="bottom">Remove from favourites</md-tooltip>
+                      </md-icon>
+                      <md-icon v-else>
+                        favorite_border<md-tooltip md-direction="bottom">Add to favorites</md-tooltip>
+                      </md-icon>
+                  </md-button>
                 </div>
 
                 <md-card-expand-trigger>
@@ -60,13 +61,11 @@
 <script>
 export default {
   name: 'PokeArc',
-  props: ['settings'],
+  props: ['settings', 'favourites'],
   data () {
     return {
       pokemons: [],
-      favPokemon: [],
       limit: 5,
-      popup: false,
       offset: 0
     }
   },
@@ -103,20 +102,11 @@ export default {
     showProgressBar: function () {
       document.getElementById('progress-bar').style.visibility = 'visible'
     },
-    addToFav: function (pokeid) {
-      if (this.favPokemon.indexOf(pokeid) < 0) {
-        this.favPokemon.push(pokeid)
-      } else {
-        this.favPokemon.pop(this.favPokemon.indexOf(pokeid))
-      }
-      localStorage.setItem('favPokemon', JSON.stringify(this.favPokemon))
-      this.favPokemon = JSON.parse(localStorage.getItem('favPokemon'))
+    toggleFavourite: function (pokeid) {
+      this.$emit('favourite', pokeid)
     }
   },
   beforeMount () {
-    if (localStorage.getItem('favPokemon')) {
-      this.favPokemon = JSON.parse(localStorage.getItem('favPokemon'))
-    }
     this.getPokemons(5, 0)
   }
 }


### PR DESCRIPTION
Fixes #3 

Make favourites app data and use events to emit changes to favourites pokemon array.
Pass favourites down to required components.
Store favourites in localStorage
Remove popup as favourites is now reactive.